### PR TITLE
VirtualScreen - managing viewer api

### DIFF
--- a/src/main/java/me/squidxtv/frameui/core/AbstractScreen.java
+++ b/src/main/java/me/squidxtv/frameui/core/AbstractScreen.java
@@ -14,9 +14,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
+
 public abstract class AbstractScreen<G extends AbstractGraphics<?>> implements Screen<G> {
 
-    protected static final ScreenRegistry SCREEN_REGISTRY = Bukkit.getServicesManager().load(ScreenRegistry.class);
+    protected static final ScreenRegistry SCREEN_REGISTRY = Objects.requireNonNull(Bukkit.getServicesManager().load(ScreenRegistry.class));
 
     private final @NotNull JavaPlugin plugin;
     private @NotNull ScreenModel model;

--- a/src/main/java/me/squidxtv/frameui/core/VirtualScreen.java
+++ b/src/main/java/me/squidxtv/frameui/core/VirtualScreen.java
@@ -5,6 +5,7 @@ import me.squidxtv.frameui.core.actions.initiator.PlayerInitiator;
 import me.squidxtv.frameui.core.actions.scroll.ScrollDirection;
 import me.squidxtv.frameui.core.content.ScreenModel;
 import me.squidxtv.frameui.core.graphics.VirtualGraphics;
+import me.squidxtv.frameui.core.map.VirtualMap;
 import me.squidxtv.frameui.core.math.BoundingBox;
 import me.squidxtv.frameui.core.math.Direction;
 import org.bukkit.Location;
@@ -12,7 +13,10 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -32,6 +36,20 @@ public class VirtualScreen extends AbstractScreen<VirtualGraphics> {
         this.world = world;
         this.topLeftFrameLocation = topLeftFrameLocation;
         this.direction = direction;
+    }
+
+    @Override
+    public void open() {
+        super.open();
+        for (VirtualMap map : getGraphics().getMaps()) {
+            map.getPacket().send(viewer);
+        }
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        VirtualMap.Packet.destroy(getGraphics().getMaps(), viewer);
     }
 
     @Override
@@ -89,7 +107,82 @@ public class VirtualScreen extends AbstractScreen<VirtualGraphics> {
         getGraphics().setDirection(direction);
     }
 
+    @UnmodifiableView
+    public @NotNull Collection<Player> getViewer() {
+        return Collections.unmodifiableSet(viewer);
+    }
+
     public boolean containsViewer(@NotNull Player player) {
         return viewer.contains(player);
+    }
+
+    public void addViewer(@NotNull Player player) {
+        throwIfRemoved();
+
+        if (!viewer.add(player)) {
+            return;
+        }
+
+        if (getState() == State.CLOSED) {
+            return;
+        }
+
+        for (VirtualMap map : getGraphics().getMaps()) {
+            map.getPacket().send(player);
+        }
+    }
+
+    public void addViewer(@NotNull Collection<Player> players) {
+        throwIfRemoved();
+
+        if (!viewer.addAll(players)) {
+            return;
+        }
+
+        if (getState() == State.CLOSED) {
+            return;
+        }
+
+        for (VirtualMap map : getGraphics().getMaps()) {
+            map.getPacket().send(players);
+        }
+    }
+
+    public void removeViewer(@NotNull Player player) {
+        throwIfRemoved();
+
+        if (!viewer.remove(player)) {
+            return;
+        }
+
+        if (getState() == State.CLOSED) {
+            return;
+        }
+
+        VirtualMap.Packet.destroy(getGraphics().getMaps(), player);
+    }
+
+    public void removeViewer(@NotNull Collection<Player> players) {
+        throwIfRemoved();
+
+        if (!viewer.removeAll(players)) {
+            return;
+        }
+
+        if (getState() == State.CLOSED) {
+            return;
+        }
+
+        VirtualMap.Packet.destroy(getGraphics().getMaps(), players);
+    }
+
+    public void clearViewer() {
+        throwIfRemoved();
+
+        if (getState() == State.OPEN) {
+            VirtualMap.Packet.destroy(getGraphics().getMaps(), viewer);
+        }
+
+        viewer.clear();
     }
 }

--- a/src/main/java/me/squidxtv/frameui/core/graphics/VirtualGraphics.java
+++ b/src/main/java/me/squidxtv/frameui/core/graphics/VirtualGraphics.java
@@ -81,4 +81,5 @@ public class VirtualGraphics extends AbstractGraphics<VirtualMap> {
     public void setDirection(@NotNull Direction direction) {
         this.direction = direction;
     }
+
 }

--- a/src/main/java/me/squidxtv/frameui/core/map/VirtualMap.java
+++ b/src/main/java/me/squidxtv/frameui/core/map/VirtualMap.java
@@ -19,15 +19,13 @@ import org.bukkit.map.MapView;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.*;
 import java.util.List;
-import java.util.UUID;
 import java.util.logging.Logger;
 
 public class VirtualMap extends AbstractMap {
 
-    private static final @NotNull Logger LOGGER = Bukkit.getServicesManager().load(FrameAPI.class).getLogger();
+    private static final @NotNull Logger LOGGER = Objects.requireNonNull(Bukkit.getServicesManager().load(FrameAPI.class)).getLogger();
 
     private final @NotNull Location location;
     private final @NotNull Direction direction;
@@ -45,6 +43,7 @@ public class VirtualMap extends AbstractMap {
     public void update(@NotNull Color pixel, int x, int y) {
         renderer.setPixel(pixel, x, y);
     }
+
     public @NotNull Location getLocation() {
         return location;
     }
@@ -149,7 +148,6 @@ public class VirtualMap extends AbstractMap {
             send(List.of(player));
         }
 
-        // use static method instead
         public void destroy(@NotNull Collection<Player> players) {
             PacketContainer destroy = PROTOCOL_MANAGER.createPacket(PacketType.Play.Server.ENTITY_DESTROY);
             destroy.getIntLists().write(0, List.of(entityId));
@@ -157,14 +155,13 @@ public class VirtualMap extends AbstractMap {
                 PROTOCOL_MANAGER.sendServerPacket(player, destroy);
             }
         }
-    
-        // use static method instead
+
         public void destroy(@NotNull Player player) {
             destroy(List.of(player));
         }
         
-        public static void destroy(@NotNull VirtualMap[][] maps, @NotNull Collection<Player> players) {
-            List<Integer> ids = Arrays.stream(maps).flatMap(Arrays::stream).map(virtualMap -> virtualMap.packet.entityId).toList();
+        public static void destroy(@NotNull VirtualMap[] maps, @NotNull Collection<Player> players) {
+            List<Integer> ids = Arrays.stream(maps).map(virtualMap -> virtualMap.packet.entityId).toList();
             PacketContainer destroy = PROTOCOL_MANAGER.createPacket(PacketType.Play.Server.ENTITY_DESTROY);
             destroy.getIntegers().write(0, ids.size());
             destroy.getIntLists().write(0, ids);
@@ -173,7 +170,7 @@ public class VirtualMap extends AbstractMap {
             }
         }
 
-        public static void destroy(@NotNull VirtualMap[][] maps, @NotNull Player player) {
+        public static void destroy(@NotNull VirtualMap[] maps, @NotNull Player player) {
             destroy(maps, List.of(player));
         }
         


### PR DESCRIPTION
# About
closes #14 
Add the methods to manage viewer in a `VirtualScreen`.
Correctly destroy/send packets to new/old viewer.