### PR TITLE
Builder class for creating and configuring instances of Screen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ val packetEventsVersion = "2.4.0"
 val mockitoVersion = "5.12.0"
 
 dependencies {
+    compileOnly("org.projectlombok:lombok:1.18.34")
     compileOnly("org.spigotmc:spigot-api:$spigotVersion")
     compileOnly("com.github.retrooper:packetevents-spigot:$packetEventsVersion")
 
@@ -30,6 +31,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
     testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
+
+    annotationProcessor("org.projectlombok:lombok:1.18.34")
 }
 
 java {

--- a/src/main/java/me/squidxtv/frameui/FrameUI.java
+++ b/src/main/java/me/squidxtv/frameui/FrameUI.java
@@ -1,5 +1,6 @@
 package me.squidxtv.frameui;
 
+import me.squidxtv.frameui.api.FramesApi;
 import me.squidxtv.frameui.api.ScreenRegistry;
 import me.squidxtv.frameui.api.ScreenRegistryImpl;
 import me.squidxtv.frameui.listener.ClickListener;
@@ -19,7 +20,7 @@ public class FrameUI extends JavaPlugin {
         saveDefaultConfig();
         Server server = getServer();
 
-        ScreenRegistry registry = new ScreenRegistryImpl();
+        ScreenRegistry registry = new ScreenRegistryImpl(this);
         ServicesManager services = server.getServicesManager();
         services.register(ScreenRegistry.class, registry, this, ServicePriority.Normal);
 

--- a/src/main/java/me/squidxtv/frameui/api/FramesApi.java
+++ b/src/main/java/me/squidxtv/frameui/api/FramesApi.java
@@ -5,30 +5,42 @@ import me.squidxtv.frameui.api.exceptions.FramesApiException;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.ServicesManager;
 
-
+/**
+ * FramesApi provides methods to interact with the screen management system within the plugin.
+ * It allows for the creation and management of screen objects.
+ */
 public interface FramesApi {
     /**
-     * @return true if library has been initialed
+     * Checks if the Frames API library has been initialized.
+     *
+     * @return true if the library has been initialized, false otherwise.
      */
     static boolean isInitialized() {
         return getServices().isProvidedFor(ScreenRegistry.class);
     }
 
     /**
-     * Use this method to create new screen
+     * Creates a new ScreenBuilder instance, which is a flexible creator for new screen objects.
      * <p>
-     * code```
-     * <p>
-     * var screen = FramesApi
-     * .newScreen()
-     * .withName("Default screen!")
-     * .withSize(10, 10)
-     * .build();
-     * <p>
-     * screen.open();
-     * ```
+     * Example usage:
+     * <pre>
+     * {@code
+     * public void example(ScreenRegistry registry) {
+     *     var player = Bukkit.getPlayer("mike");
+     *     var screen = FramesApi.newScreen()
+     *             .withSize(10, 10)
+     *             .withViewer(player)
+     *             .withName("Main Menu Screen")
+     *             .withLocation(player.getLocation())
+     *             .build();
      *
-     * @return screen creator
+     *     screen.open();
+     * }
+     * }
+     * </pre>
+     *
+     * @return a new instance of ScreenBuilder.
+     * @throws FramesApiException if the library has not been initialized.
      * @see ScreenBuilder
      */
     static ScreenBuilder newScreen() {
@@ -37,8 +49,10 @@ public interface FramesApi {
 
 
     /**
-     * @return ScreenRegistry object that manage all screens
-     * @throws FramesApiException when library has not been initialized
+     * Returns the ScreenRegistry instance that manages all screens.
+     *
+     * @return the ScreenRegistry instance that manages all screens.
+     * @throws FramesApiException if the library has not been initialized.
      * @see ScreenRegistry
      */
     static ScreenRegistry screens() {

--- a/src/main/java/me/squidxtv/frameui/api/FramesApi.java
+++ b/src/main/java/me/squidxtv/frameui/api/FramesApi.java
@@ -20,7 +20,7 @@ public interface FramesApi {
     }
 
     /**
-     * Creates a new {@link ScreenBuilder} instance, which is a flexible creator for new {@link me.squidxtv.frameui.core.Screen} objects.
+     * Creates a new {@link ScreenBuilder} instance, which is a flexible creator for new {@link me.squidxtv.frameui.core.Screen} object.
      * <p>
      * Example usage:
      * <pre>
@@ -39,7 +39,7 @@ public interface FramesApi {
      * }
      * </pre>
      *
-     * @return a new instance of ScreenBuilder.
+     * @return a new instance of {@link ScreenBuilder}.
      * @throws FramesApiException if the library has not been initialized.
      * @see ScreenBuilder
      */

--- a/src/main/java/me/squidxtv/frameui/api/FramesApi.java
+++ b/src/main/java/me/squidxtv/frameui/api/FramesApi.java
@@ -5,28 +5,42 @@ import me.squidxtv.frameui.api.exceptions.FramesApiException;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.ServicesManager;
 
-/**
- * code```
- * <p>
- * var screen = FramesApi
- * .newScreen()
- * .withName("Default screen!")
- * .withSize(10, 10)
- * .build();
- * <p>
- * screen.open();
- * ```
- */
-public interface FramesApi {
 
+public interface FramesApi {
+    /**
+     * @return true if library has been initialed
+     */
     static boolean isInitialized() {
         return getServices().isProvidedFor(ScreenRegistry.class);
     }
 
+    /**
+     * Use this method to create new screen
+     * <p>
+     * code```
+     * <p>
+     * var screen = FramesApi
+     * .newScreen()
+     * .withName("Default screen!")
+     * .withSize(10, 10)
+     * .build();
+     * <p>
+     * screen.open();
+     * ```
+     *
+     * @return screen creator
+     * @see ScreenBuilder
+     */
     static ScreenBuilder newScreen() {
         return screens().newScreen();
     }
 
+
+    /**
+     * @return ScreenRegistry object that manage all screens
+     * @throws FramesApiException when library has not been initialized
+     * @see ScreenRegistry
+     */
     static ScreenRegistry screens() {
         if (!isInitialized()) {
             throw new FramesApiException("Frames Api has not been initialized yet!");

--- a/src/main/java/me/squidxtv/frameui/api/FramesApi.java
+++ b/src/main/java/me/squidxtv/frameui/api/FramesApi.java
@@ -1,0 +1,41 @@
+package me.squidxtv.frameui.api;
+
+import me.squidxtv.frameui.api.builder.ScreenBuilder;
+import me.squidxtv.frameui.api.exceptions.FramesApiException;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.ServicesManager;
+
+/**
+ * code```
+ * <p>
+ * var screen = FramesApi
+ * .newScreen()
+ * .withName("Default screen!")
+ * .withSize(10, 10)
+ * .build();
+ * <p>
+ * screen.open();
+ * ```
+ */
+public interface FramesApi {
+
+    static boolean isInitialized() {
+        return getServices().isProvidedFor(ScreenRegistry.class);
+    }
+
+    static ScreenBuilder newScreen() {
+        return screens().newScreen();
+    }
+
+    static ScreenRegistry screens() {
+        if (!isInitialized()) {
+            throw new FramesApiException("Frames Api has not been initialized yet!");
+        }
+        return getServices().load(ScreenRegistry.class);
+    }
+
+    private static ServicesManager getServices() {
+        return Bukkit.getServer().getServicesManager();
+    }
+
+}

--- a/src/main/java/me/squidxtv/frameui/api/FramesApi.java
+++ b/src/main/java/me/squidxtv/frameui/api/FramesApi.java
@@ -20,7 +20,7 @@ public interface FramesApi {
     }
 
     /**
-     * Creates a new ScreenBuilder instance, which is a flexible creator for new screen objects.
+     * Creates a new {@link ScreenBuilder} instance, which is a flexible creator for new {@link me.squidxtv.frameui.core.Screen} objects.
      * <p>
      * Example usage:
      * <pre>
@@ -49,7 +49,7 @@ public interface FramesApi {
 
 
     /**
-     * Returns the ScreenRegistry instance that manages all screens.
+     * Returns the {@link ScreenRegistry} instance that manages all screens.
      *
      * @return the ScreenRegistry instance that manages all screens.
      * @throws FramesApiException if the library has not been initialized.

--- a/src/main/java/me/squidxtv/frameui/api/ScreenRegistry.java
+++ b/src/main/java/me/squidxtv/frameui/api/ScreenRegistry.java
@@ -9,12 +9,23 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * The {@code ScreenRegistry} interface is used to manage {@link Screen} instances across the entire server.
+ * The {@link  ScreenRegistry} interface is used to manage {@link Screen} instances across the entire server.
  */
 public interface ScreenRegistry {
 
     /**
-     * @return {@link ScreenBuilder} a class for easy and fluent creating of a new screen
+     * Creates a new instance of {@link ScreenBuilder} for easy and fluent creation of a new screen.
+     * This method allows specifying the plugin context.
+     *
+     * @param plugin the plugin instance that is creating the screen
+     * @return a {@link ScreenBuilder} instance for creating a new screen
+     */
+    ScreenBuilder newScreen(Plugin plugin);
+
+    /**
+     * Creates a new instance of {@link ScreenBuilder} for easy and fluent creation of a new screen.
+     *
+     * @return a {@link ScreenBuilder} instance for creating a new screen
      */
     ScreenBuilder newScreen();
 

--- a/src/main/java/me/squidxtv/frameui/api/ScreenRegistry.java
+++ b/src/main/java/me/squidxtv/frameui/api/ScreenRegistry.java
@@ -14,10 +14,9 @@ import java.util.UUID;
 public interface ScreenRegistry {
 
     /**
-     * @param plugin the screen's plugin
      * @return {@link ScreenBuilder} a class for easy and fluent creating of a new screen
      */
-    ScreenBuilder create(Plugin plugin);
+    ScreenBuilder newScreen();
 
     /**
      * Adds a {@link Screen} to the registry.

--- a/src/main/java/me/squidxtv/frameui/api/ScreenRegistry.java
+++ b/src/main/java/me/squidxtv/frameui/api/ScreenRegistry.java
@@ -1,5 +1,6 @@
 package me.squidxtv.frameui.api;
 
+import me.squidxtv.frameui.api.builder.ScreenBuilder;
 import me.squidxtv.frameui.core.Screen;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -11,6 +12,12 @@ import java.util.UUID;
  * The {@code ScreenRegistry} interface is used to manage {@link Screen} instances across the entire server.
  */
 public interface ScreenRegistry {
+
+    /**
+     * @param plugin the screen's plugin
+     * @return {@link ScreenBuilder} a class for easy and fluent creating of a new screen
+     */
+    ScreenBuilder create(Plugin plugin);
 
     /**
      * Adds a {@link Screen} to the registry.
@@ -28,12 +35,14 @@ public interface ScreenRegistry {
 
     /**
      * Returns a list of all screens in the registry.
+     *
      * @return a list of all screens
      */
     List<Screen> getAll();
 
     /**
      * Returns a list of screens associated with a specific plugin.
+     *
      * @param plugin the plugin to filter registered screens by
      * @return a list of screens associated with the given plugin
      */
@@ -41,13 +50,23 @@ public interface ScreenRegistry {
 
     /**
      * Returns a list of screens that contain the specific player as a viewer.
+     *
      * @param viewer the viewer to filter registered screens by
      * @return a list of screens that contain the given viewer
      */
     List<Screen> getByViewer(Player viewer);
 
     /**
+     * Retrieves a list of {@link Screen} instances that have the specified name.
+     *
+     * @param name the name of the screens to retrieve
+     * @return a list of {@link Screen} instances with the specified name
+     */
+    List<Screen> getByName(String name);
+
+    /**
      * Returns a list of screens that contain the specific uuid of a viewer.
+     *
      * @param uuid the uuid to filter registered screens by
      * @return a list of screens that contain the given uuid of a viewer
      */

--- a/src/main/java/me/squidxtv/frameui/api/ScreenRegistryImpl.java
+++ b/src/main/java/me/squidxtv/frameui/api/ScreenRegistryImpl.java
@@ -14,8 +14,14 @@ public class ScreenRegistryImpl implements ScreenRegistry {
 
     private final List<Screen> registered = new ArrayList<>();
 
+    private final Plugin plugin;
+
+    public ScreenRegistryImpl(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
     @Override
-    public ScreenBuilder create(Plugin plugin) {
+    public ScreenBuilder newScreen() {
         return new ScreenBuilderImpl(plugin, this);
     }
 

--- a/src/main/java/me/squidxtv/frameui/api/ScreenRegistryImpl.java
+++ b/src/main/java/me/squidxtv/frameui/api/ScreenRegistryImpl.java
@@ -20,9 +20,14 @@ public class ScreenRegistryImpl implements ScreenRegistry {
         this.plugin = plugin;
     }
 
+
+    public ScreenBuilder newScreen(Plugin plugin) {
+        return new ScreenBuilderImpl(plugin, this);
+    }
+
     @Override
     public ScreenBuilder newScreen() {
-        return new ScreenBuilderImpl(plugin, this);
+        return newScreen(plugin);
     }
 
     @Override

--- a/src/main/java/me/squidxtv/frameui/api/ScreenRegistryImpl.java
+++ b/src/main/java/me/squidxtv/frameui/api/ScreenRegistryImpl.java
@@ -1,6 +1,8 @@
 package me.squidxtv.frameui.api;
 
+import me.squidxtv.frameui.api.builder.ScreenBuilder;
 import me.squidxtv.frameui.core.Screen;
+import me.squidxtv.frameui.core.builder.ScreenBuilderImpl;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
@@ -11,6 +13,11 @@ import java.util.UUID;
 public class ScreenRegistryImpl implements ScreenRegistry {
 
     private final List<Screen> registered = new ArrayList<>();
+
+    @Override
+    public ScreenBuilder create(Plugin plugin) {
+        return new ScreenBuilderImpl(plugin, this);
+    }
 
     @Override
     public void add(Screen screen) {
@@ -35,6 +42,11 @@ public class ScreenRegistryImpl implements ScreenRegistry {
     @Override
     public List<Screen> getByViewer(Player viewer) {
         return registered.stream().filter(screen -> screen.hasViewer(viewer)).toList();
+    }
+
+    @Override
+    public List<Screen> getByName(String name) {
+        return registered.stream().filter(screen -> screen.getName().equals(name)).toList();
     }
 
     @Override

--- a/src/main/java/me/squidxtv/frameui/api/builder/ScreenBuilder.java
+++ b/src/main/java/me/squidxtv/frameui/api/builder/ScreenBuilder.java
@@ -9,32 +9,35 @@ import org.bukkit.entity.Player;
 
 import java.util.Collection;
 
+
 /**
  * Builder class for creating and configuring instances of {@link Screen}.
  * This builder uses a fluent API style, enabling method chaining for ease of use.
- *
  */
 public interface ScreenBuilder {
 
     /**
-     * Sets width of the screen
+     * Sets the width of the screen.
      *
      * @param width the number of horizontal item frames
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withWidth(int width);
 
     /**
-     * Sets height of the screen
+     * Sets the height of the screen.
      *
      * @param height the number of vertical item frames
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withHeight(int height);
 
     /**
-     * Sets size of the screen in item frames number
+     * Sets the size of the screen in item frames.
      *
      * @param width  the number of horizontal item frames
      * @param height the number of vertical item frames
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withSize(int width, int height);
 
@@ -42,52 +45,56 @@ public interface ScreenBuilder {
      * Sets the name of the screen. The name can be used as a screen identifier.
      *
      * @param name the name of the screen
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withName(String name);
 
     /**
-     * Sets minimal distance from with player can interact with screen
+     * Sets the minimal distance from which a player can interact with the screen.
      *
-     * @param radios value of the radios
-     * @return
+     * @param radius the interaction radius
+     * @return this builder instance for method chaining
      */
-    ScreenBuilder withClickRadius(double radios);
+    ScreenBuilder withClickRadius(double radius);
 
     /**
-     * Sets value of the scrollRadios
+     * Sets the scroll radius for the screen.
      *
-     * @param scrollRadios value of the scrollRadios
-     * @return
+     * @param scrollRadius the scroll radius
+     * @return this builder instance for method chaining
      */
-    ScreenBuilder withScrollRadius(double scrollRadios);
+    ScreenBuilder withScrollRadius(double scrollRadius);
 
     /**
      * Adds a viewer to the screen. Multiple viewers can be added by calling this method multiple times.
-     * When screen location haven't set yet, then sets screen location as player location
+     * If the screen location has not been set yet, it sets the screen location as the player's location.
      *
      * @param player the player to add as a viewer
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withViewer(Player player);
 
     /**
-     * Perform withViewer method for multiple players
+     * Adds multiple viewers to the screen.
      *
-     * @param players array of players
+     * @param players an array of players
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withViewer(Player... players);
 
     /**
-     * Perform withViewer method for multiple players
+     * Adds multiple viewers to the screen.
      *
-     * @param players collection of players
+     * @param players a collection of players
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withViewer(Collection<Player> players);
-
 
     /**
      * Sets the location of the screen.
      *
      * @param location the location of the screen
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withLocation(Location location);
 
@@ -96,6 +103,7 @@ public interface ScreenBuilder {
      *
      * @param location  the location of the screen
      * @param direction the direction in which the screen is facing
+     * @return this builder instance for method chaining
      */
     ScreenBuilder withLocation(Location location, Direction direction);
 
@@ -103,17 +111,19 @@ public interface ScreenBuilder {
      * Sets the renderer for the screen.
      *
      * @param renderer the renderer to be used for the screen
+     * @return this builder instance for method chaining
+     * @see Renderer
      */
     ScreenBuilder withRenderer(Renderer renderer);
-
 
     /**
      * Sets the ScreenSpawner for the screen.
      *
      * @param spawner used to perform spawning screen to players
+     * @return this builder instance for method chaining
+     * @see ScreenSpawner
      */
     ScreenBuilder withSpawner(ScreenSpawner spawner);
-
 
     /**
      * Builds a new instance of {@link Screen} based on the current configuration of the builder.

--- a/src/main/java/me/squidxtv/frameui/api/builder/ScreenBuilder.java
+++ b/src/main/java/me/squidxtv/frameui/api/builder/ScreenBuilder.java
@@ -2,9 +2,12 @@ package me.squidxtv.frameui.api.builder;
 
 import me.squidxtv.frameui.core.Renderer;
 import me.squidxtv.frameui.core.Screen;
+import me.squidxtv.frameui.core.ScreenSpawner;
 import me.squidxtv.frameui.math.Direction;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+
+import java.util.Collection;
 
 /**
  * Builder class for creating and configuring instances of {@link Screen}.
@@ -16,7 +19,7 @@ import org.bukkit.entity.Player;
  * {@code
  * public void example(ScreenRegistry registry) {
  *     var player = Bukkit.getPlayer("mike");
- *     var screen = registry.create(this)
+ *     var screen = FramesApi.newScreen()
  *             .withSize(10, 10)
  *             .withViewer(player)
  *             .withName("Main Menu Screen")
@@ -54,11 +57,41 @@ public interface ScreenBuilder {
     ScreenBuilder withName(String name);
 
     /**
+     * Sets minimal distance from with player can interact with screen
+     *
+     * @param radios value of the radios
+     * @return
+     */
+    ScreenBuilder withClickRadius(double radios);
+
+    /**
+     * @param scrollRadios value of the scrollRadios
+     * @return
+     */
+    ScreenBuilder withScrollRadius(double scrollRadios);
+
+    /**
      * Adds a viewer to the screen. Multiple viewers can be added by calling this method multiple times.
+     * When screen location haven't set yet, then sets screen location as player location
      *
      * @param player the player to add as a viewer
      */
     ScreenBuilder withViewer(Player player);
+
+    /**
+     * Perform withViewer method for multiple players
+     *
+     * @param players array of players
+     */
+    ScreenBuilder withViewer(Player... players);
+
+    /**
+     * Perform withViewer method for multiple players
+     *
+     * @param players collection of players
+     */
+    ScreenBuilder withViewer(Collection<Player> players);
+
 
     /**
      * Sets the location of the screen.
@@ -81,6 +114,15 @@ public interface ScreenBuilder {
      * @param renderer the renderer to be used for the screen
      */
     ScreenBuilder withRenderer(Renderer renderer);
+
+
+    /**
+     * Sets the ScreenSpawner for the screen.
+     *
+     * @param spawner used to perform spawning screen to players
+     */
+    ScreenBuilder withSpawner(ScreenSpawner spawner);
+
 
     /**
      * Builds a new instance of {@link Screen} based on the current configuration of the builder.

--- a/src/main/java/me/squidxtv/frameui/api/builder/ScreenBuilder.java
+++ b/src/main/java/me/squidxtv/frameui/api/builder/ScreenBuilder.java
@@ -1,0 +1,99 @@
+package me.squidxtv.frameui.api.builder;
+
+import me.squidxtv.frameui.core.Renderer;
+import me.squidxtv.frameui.core.Screen;
+import me.squidxtv.frameui.math.Direction;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+/**
+ * Builder class for creating and configuring instances of {@link Screen}.
+ * This builder uses a fluent API style, enabling method chaining for ease of use.
+ *
+ * <p>Example usage:</p>
+ *
+ * <pre>
+ * {@code
+ * public void example(ScreenRegistry registry) {
+ *     var player = Bukkit.getPlayer("mike");
+ *     var screen = registry.create(this)
+ *             .withSize(10, 10)
+ *             .withViewer(player)
+ *             .withName("Main Menu Screen")
+ *             .withLocation(player.getLocation())
+ *             .build();
+ *
+ *     screen.open();
+ * }
+ * }
+ * </pre>
+ */
+public interface ScreenBuilder {
+
+    /**
+     * @param width the number of horizontal item frames
+     */
+    ScreenBuilder withWidth(int width);
+
+    /**
+     * @param height the number of vertical item frames
+     */
+    ScreenBuilder withHeight(int height);
+
+    /**
+     * @param width  the number of horizontal item frames
+     * @param height the number of vertical item frames
+     */
+    ScreenBuilder withSize(int width, int height);
+
+    /**
+     * Sets the name of the screen. The name can be used as a screen identifier.
+     *
+     * @param name the name of the screen
+     */
+    ScreenBuilder withName(String name);
+
+    /**
+     * Adds a viewer to the screen. Multiple viewers can be added by calling this method multiple times.
+     *
+     * @param player the player to add as a viewer
+     */
+    ScreenBuilder withViewer(Player player);
+
+    /**
+     * Sets the location of the screen.
+     *
+     * @param location the location of the screen
+     */
+    ScreenBuilder withLocation(Location location);
+
+    /**
+     * Sets the location and direction of the screen.
+     *
+     * @param location  the location of the screen
+     * @param direction the direction in which the screen is facing
+     */
+    ScreenBuilder withLocation(Location location, Direction direction);
+
+    /**
+     * Sets the renderer for the screen.
+     *
+     * @param renderer the renderer to be used for the screen
+     */
+    ScreenBuilder withRenderer(Renderer renderer);
+
+    /**
+     * Builds a new instance of {@link Screen} based on the current configuration of the builder.
+     *
+     * @return a new instance of {@link Screen}
+     */
+    Screen build();
+
+    /**
+     * Builds a new instance of {@link Screen} based on the current configuration of the builder
+     * and opens it immediately.
+     *
+     * @return a new instance of {@link Screen}
+     */
+    Screen buildAndOpen();
+}

--- a/src/main/java/me/squidxtv/frameui/api/builder/ScreenBuilder.java
+++ b/src/main/java/me/squidxtv/frameui/api/builder/ScreenBuilder.java
@@ -13,37 +13,26 @@ import java.util.Collection;
  * Builder class for creating and configuring instances of {@link Screen}.
  * This builder uses a fluent API style, enabling method chaining for ease of use.
  *
- * <p>Example usage:</p>
- *
- * <pre>
- * {@code
- * public void example(ScreenRegistry registry) {
- *     var player = Bukkit.getPlayer("mike");
- *     var screen = FramesApi.newScreen()
- *             .withSize(10, 10)
- *             .withViewer(player)
- *             .withName("Main Menu Screen")
- *             .withLocation(player.getLocation())
- *             .build();
- *
- *     screen.open();
- * }
- * }
- * </pre>
  */
 public interface ScreenBuilder {
 
     /**
+     * Sets width of the screen
+     *
      * @param width the number of horizontal item frames
      */
     ScreenBuilder withWidth(int width);
 
     /**
+     * Sets height of the screen
+     *
      * @param height the number of vertical item frames
      */
     ScreenBuilder withHeight(int height);
 
     /**
+     * Sets size of the screen in item frames number
+     *
      * @param width  the number of horizontal item frames
      * @param height the number of vertical item frames
      */
@@ -65,6 +54,8 @@ public interface ScreenBuilder {
     ScreenBuilder withClickRadius(double radios);
 
     /**
+     * Sets value of the scrollRadios
+     *
      * @param scrollRadios value of the scrollRadios
      * @return
      */

--- a/src/main/java/me/squidxtv/frameui/api/data/ScreenProperties.java
+++ b/src/main/java/me/squidxtv/frameui/api/data/ScreenProperties.java
@@ -1,0 +1,26 @@
+package me.squidxtv.frameui.api.data;
+
+import lombok.Data;
+import me.squidxtv.frameui.core.Screen;
+import me.squidxtv.frameui.core.ScreenLocation;
+import org.joml.Vector2i;
+
+
+@Data
+public class ScreenProperties {
+
+    private String name;
+    private Vector2i size;
+    private ScreenLocation screenLocation;
+    private double clickRadius;
+    private double scrollRadius;
+    private Screen.State state = Screen.State.CLOSED;
+
+    public int getWidth() {
+        return size.x;
+    }
+
+    public int getHeight() {
+        return size.y;
+    }
+}

--- a/src/main/java/me/squidxtv/frameui/api/exceptions/FramesApiException.java
+++ b/src/main/java/me/squidxtv/frameui/api/exceptions/FramesApiException.java
@@ -1,7 +1,9 @@
 package me.squidxtv.frameui.api.exceptions;
 
-public class FramesApiException extends RuntimeException
-{
+/**
+ * General exception for all errors related to Frames Api
+ */
+public class FramesApiException extends RuntimeException {
     public FramesApiException() {
     }
 

--- a/src/main/java/me/squidxtv/frameui/api/exceptions/FramesApiException.java
+++ b/src/main/java/me/squidxtv/frameui/api/exceptions/FramesApiException.java
@@ -1,0 +1,23 @@
+package me.squidxtv.frameui.api.exceptions;
+
+public class FramesApiException extends RuntimeException
+{
+    public FramesApiException() {
+    }
+
+    public FramesApiException(String message) {
+        super(message);
+    }
+
+    public FramesApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FramesApiException(Throwable cause) {
+        super(cause);
+    }
+
+    public FramesApiException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/me/squidxtv/frameui/core/Screen.java
+++ b/src/main/java/me/squidxtv/frameui/core/Screen.java
@@ -34,7 +34,6 @@ public class Screen implements Clickable, Scrollable {
 
     private final Plugin plugin;
     private final Set<UUID> viewers = new HashSet<>();
-
     private final ItemFrame[][] itemFrames;
 
     private final int width;
@@ -47,6 +46,7 @@ public class Screen implements Clickable, Scrollable {
     private ClickEventHandler clickEventHandler = ClickEventHandler.empty();
     private ScrollEventHandler scrollEventHandler = ScrollEventHandler.empty();
 
+    private String name;
     private double clickRadius = 20;
     private double scrollRadius = 20;
 
@@ -63,11 +63,11 @@ public class Screen implements Clickable, Scrollable {
     /**
      * Creates a new screen with the specified plugin, dimensions, location, spawner and renderer.
      *
-     * @param plugin the plugin associated with this screen
-     * @param width the block width of the screen
-     * @param height the block height of the screen
+     * @param plugin   the plugin associated with this screen
+     * @param width    the block width of the screen
+     * @param height   the block height of the screen
      * @param location the location of the screen
-     * @param spawner the spawner responsible for spawning the screen's item frames
+     * @param spawner  the spawner responsible for spawning the screen's item frames
      * @param renderer the renderer responsible for rendering the screen's content
      * @throws NullPointerException if {@code plugin}, {@code location}, {@code spawner}, or {@code renderer} is null
      */
@@ -85,6 +85,7 @@ public class Screen implements Clickable, Scrollable {
 
         this.spawner = spawner;
         this.renderer = renderer;
+        this.name = UUID.randomUUID().toString();
     }
 
 
@@ -92,11 +93,11 @@ public class Screen implements Clickable, Scrollable {
      * Creates a new screen with the specified plugin, dimensions and location.
      * Uses packets for spawning and a {@link BufferedImage} for rendering.
      *
-     * @param plugin the plugin associated with this screen
-     * @param width the block width of the screen
-     * @param height the block height of the screen
+     * @param plugin   the plugin associated with this screen
+     * @param width    the block width of the screen
+     * @param height   the block height of the screen
      * @param location the location of the screen
-     * @param image the image rendered on the image
+     * @param image    the image rendered on the image
      * @throws NullPointerException if {@code plugin}, {@code location} or {@code image} is null
      */
     public Screen(Plugin plugin, int width, int height, ScreenLocation location, BufferedImage image) {
@@ -107,9 +108,9 @@ public class Screen implements Clickable, Scrollable {
      * Creates a new screen with the specified plugin, dimensions and location.
      * Uses packets for spawning and a default image for rendering.
      *
-     * @param plugin the plugin associated with this screen
-     * @param width the block width of the screen
-     * @param height the block height of the screen
+     * @param plugin   the plugin associated with this screen
+     * @param width    the block width of the screen
+     * @param height   the block height of the screen
      * @param location the location of the screen
      * @throws NullPointerException if {@code plugin} or {@code location} is null
      */
@@ -126,6 +127,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Opens the screen.
+     *
      * @param invisible sets the visibility of the item frames
      */
     public void open(boolean invisible) {
@@ -168,6 +170,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Adds a player to the screen's viewers.
+     *
      * @param player the player to add
      * @return {@code true} if player was added based on {@link Set#add(Object)}, {@code false} otherwise
      * @throws NullPointerException if {@code player} is null
@@ -185,6 +188,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Adds a collection of players to the screen's viewers.
+     *
      * @param players the players to add
      * @return the set including the players that actually got added based on {@link Set#add(Object)}
      * @throws NullPointerException if {@code players} is null
@@ -204,6 +208,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Removes a player form the screen's viewers.
+     *
      * @param player the player to remove
      * @return {@code true} if the player was removed, {@code false} otherwise
      * @throws NullPointerException if {@code player} is null
@@ -221,6 +226,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Removes a collection of players from the screen's viewers.
+     *
      * @param players the players to remove
      * @return the set including the players that actually got removed based on {@link Set#add(Object)}
      * @throws NullPointerException if {@code players} is null
@@ -248,6 +254,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Checks if a player is a viewer of the screen.
+     *
      * @param viewer the viewer to check
      * @return {@code true} if the player is a viewer of this screen, {@code false} otherwise
      * @throws NullPointerException if {@code viewer} is null
@@ -259,6 +266,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Checks if a player is a viewer of the screen.
+     *
      * @param uuid uuid to check
      * @return {@code true} if the player is a viewer of this screen, {@code false} otherwise
      */
@@ -268,6 +276,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the plugin associated with this screen.
+     *
      * @return the plugin associated with this screen
      */
     public Plugin getPlugin() {
@@ -276,6 +285,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the viewers of the screen.
+     *
      * @return a copy of the viewers
      */
     public Set<UUID> getViewers() {
@@ -284,14 +294,34 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the item frames that make up the screen.
+     *
      * @return a copy of the 2d array of the item frames
      */
     public ItemFrame[][] getItemFrames() {
         return Arrays.stream(itemFrames).map(arr -> arr == null ? null : arr.clone()).toArray(ItemFrame[][]::new);
     }
 
+
+    /**
+     * Sets the name of the screen
+     *
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the name of the screen
+     *
+     * @return the name of the screen
+     */
+    public String getName() {
+        return name;
+    }
+
     /**
      * Returns the renderer of the screen.
+     *
      * @return the renderer of the screen
      */
     public Renderer getRenderer() {
@@ -300,6 +330,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the spawner of the screen.
+     *
      * @return the spawner of the screen
      */
     public ScreenSpawner getSpawner() {
@@ -308,6 +339,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the location of the screen.
+     *
      * @return the screen location of the screen
      */
     public ScreenLocation getLocation() {
@@ -316,6 +348,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the block width of the screen.
+     *
      * @return the block width of the screen
      */
     public int getWidth() {
@@ -324,6 +357,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the block height of the screen.
+     *
      * @return the block height of the screen
      */
     public int getHeight() {
@@ -332,6 +366,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the pixel width of the screen.
+     *
      * @return the pixel width of the screen
      */
     public int getPixelWidth() {
@@ -340,6 +375,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the pixel height of the screen.
+     *
      * @return the pixel height of the screen
      */
     public int getPixelHeight() {
@@ -370,6 +406,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the click radius of the screen.
+     *
      * @return the click radius of the screen
      */
     public double getClickRadius() {
@@ -378,6 +415,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Sets the click radius of the screen.
+     *
      * @param clickRadius the new click radius
      * @throws IllegalArgumentException if {@code clickRadius < 0}
      */
@@ -390,6 +428,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the scroll radius of the screen.
+     *
      * @return the scroll radius of the screen
      */
     public double getScrollRadius() {
@@ -398,6 +437,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Sets the scroll radius of the screen
+     *
      * @param scrollRadius the new scroll radius
      * @throws IllegalArgumentException if {@code scrollRadius < 0}
      */
@@ -410,6 +450,7 @@ public class Screen implements Clickable, Scrollable {
 
     /**
      * Returns the current state of the screen.
+     *
      * @return the current state of the screen
      */
     public State getState() {

--- a/src/main/java/me/squidxtv/frameui/core/builder/ScreenBuilderImpl.java
+++ b/src/main/java/me/squidxtv/frameui/core/builder/ScreenBuilderImpl.java
@@ -1,0 +1,99 @@
+package me.squidxtv.frameui.core.builder;
+
+import me.squidxtv.frameui.api.ScreenRegistry;
+import me.squidxtv.frameui.api.builder.ScreenBuilder;
+import me.squidxtv.frameui.core.Renderer;
+import me.squidxtv.frameui.core.Screen;
+import me.squidxtv.frameui.core.ScreenLocation;
+import me.squidxtv.frameui.math.Direction;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.joml.Vector2i;
+
+import java.util.*;
+
+public class ScreenBuilderImpl implements ScreenBuilder {
+
+    private final Plugin plugin;
+    private final ScreenRegistry screenRegistry;
+    private final Vector2i size;
+    private final Set<Player> viewers;
+    private ScreenLocation screenLocation;
+    private Renderer renderer;
+    private String name;
+
+    public ScreenBuilderImpl(Plugin plugin, ScreenRegistry screenRegistry) {
+        this.plugin = plugin;
+        this.screenRegistry = screenRegistry;
+        this.size = new Vector2i(4, 4);
+        this.viewers = new HashSet<>();
+        this.name = "Screen";
+    }
+
+    @Override
+    public ScreenBuilder withWidth(int width) {
+        this.size.x = width;
+        return this;
+    }
+
+    @Override
+    public ScreenBuilder withHeight(int height) {
+        this.size.y = height;
+        return this;
+    }
+
+    @Override
+    public ScreenBuilder withSize(int width, int height) {
+        this.size.set(width, height);
+        return this;
+    }
+
+    @Override
+    public ScreenBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public ScreenBuilder withViewer(Player player) {
+        this.viewers.add(player);
+
+        if (screenLocation != null) {
+            return this;
+        }
+        return withLocation(player.getLocation());
+    }
+
+    @Override
+    public ScreenBuilder withLocation(Location location) {
+        return withLocation(location, Direction.EAST);
+    }
+
+    @Override
+    public ScreenBuilder withLocation(Location location, Direction direction) {
+        this.screenLocation = new ScreenLocation(location, direction);
+        return this;
+    }
+
+    @Override
+    public ScreenBuilder withRenderer(Renderer renderer) {
+        this.renderer = renderer;
+        return this;
+    }
+
+    @Override
+    public Screen build() {
+        var screen = new Screen(plugin, size.x, size.y, screenLocation);
+        screen.setName(name);
+        screenRegistry.add(screen);
+        return screen;
+    }
+
+    @Override
+    public Screen buildAndOpen() {
+        var screen = build();
+        screen.open();
+        return screen;
+    }
+}

--- a/src/main/java/me/squidxtv/frameui/core/impl/EmptyRenderer.java
+++ b/src/main/java/me/squidxtv/frameui/core/impl/EmptyRenderer.java
@@ -1,0 +1,11 @@
+package me.squidxtv.frameui.core.impl;
+
+import me.squidxtv.frameui.core.Renderer;
+import me.squidxtv.frameui.core.Screen;
+
+public class EmptyRenderer implements Renderer {
+    @Override
+    public void update(Screen screen) {
+
+    }
+}


### PR DESCRIPTION
- Add `create` method to `ScreenRegistry`. It returns new quality of life class `ScreenBuilder` that helps with creating
 `Screen` objects instance
 - Add `getByName` to `ScreenRegistry` helps find screens but `name`
 
 - Add `name` property to `Screen`, it can be used as identifier
